### PR TITLE
docs: add note about provider version pinning for Terraform 0.12.31

### DIFF
--- a/content/terraform/v1.1.x/docs/cli/run/index.mdx
+++ b/content/terraform/v1.1.x/docs/cli/run/index.mdx
@@ -9,6 +9,11 @@ Terraform's primary function is to create, modify, and destroy infrastructure
 resources to match the desired state described in a
 [Terraform configuration](/language).
 
+> **Note for Terraform v0.12.x (including 0.12.31):**  
+> When using Terraform versions earlier than 1.1.0, you should explicitly **pin provider versions** in your configuration.  
+> In v0.12.31, prerelease provider versions may not be parsed correctly, which can lead to unexpected behavior.
+
+
 When people refer to "running Terraform," they generally mean performing these
 provisioning actions in order to affect real infrastructure objects. The
 Terraform binary has many other subcommands for a wide variety of administrative


### PR DESCRIPTION
This PR updates the Terraform CLI run docs (v1.1.x) to include a note about
provider version pinning for Terraform 0.12.31 and earlier versions.

Fixes hashicorp/web-unified-docs#724
